### PR TITLE
Fix a minor bug introduced by the recent update

### DIFF
--- a/SFMT.c
+++ b/SFMT.c
@@ -16,7 +16,7 @@
  * The 3-clause BSD License is applied to this software, see
  * LICENSE.txt
  */
- 
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -55,16 +55,16 @@ inline static void swap(w128_t *array, int size);
 #if defined(HAVE_ALTIVEC)
   #include "SFMT-alti.h"
 #elif defined(HAVE_SSE2)
+/**
+ * parameters used by sse2.
+ */
+  static const w128_t sse2_param_mask = {{SFMT_MSK1, SFMT_MSK2,
+                                          SFMT_MSK3, SFMT_MSK4}};
   #if defined(_MSC_VER)
     #include "SFMT-sse2-msc.h"
   #else
     #include "SFMT-sse2.h"
   #endif
-/**
- * parameters used by sse2.
- */
-static const w128_t sse2_param_mask = {{SFMT_MSK1, SFMT_MSK2,
-                                        SFMT_MSK3, SFMT_MSK4}};
 #elif defined(HAVE_NEON)
   #include "SFMT-neon.h"
 #endif


### PR DESCRIPTION
The definition of `sse2_param_mask` was moved downward by 5f3e0cd74826f7a0c104aa3235d03ba0aa37cf33, and it caused a compilation error under SSE2 condition. I therefore put it back to the original position (i.e., above `#include "SFMT-sse2.h"`).